### PR TITLE
Updating fontawesome functionality in Button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,12 @@
-import { useState } from 'react';
 import './App.css';
 
 import { library } from '@fortawesome/fontawesome-svg-core';
-// import { fab } from '@fortawesome/free-brands-svg-icons';
+import { fab } from '@fortawesome/free-brands-svg-icons';
 import { fas } from '@fortawesome/free-solid-svg-icons';
-// import { far } from '@fortawesome/free-regular-svg-icons'
+import { far } from '@fortawesome/free-regular-svg-icons'
 
 // This exports the whole icon packs for Brand and Solid.
-library.add(fas);
+library.add(fas, fab, far);
 
 import Button from './components/Button/Button';
 
@@ -19,7 +18,7 @@ function App() {
             <h2>Button component testing</h2>
             <div  style={{display: 'flex'}}>
                 <div style={{margin: '0 5px'}}><Button text="First Button" /></div>
-                <div style={{margin: '0 5px'}}><Button text="Second Button" icon={'user'} /></div>
+                <div style={{margin: '0 5px'}}><Button text="Second Button" icon={['far', 'user']} /></div>
                 <div style={{margin: '0 5px'}}><Button text="Link Button" href={'#'} /></div>
             </div>
         </>

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styles from './Button.module.scss';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { IconName } from '@fortawesome/fontawesome-svg-core';
+import { IconName, IconProp } from '@fortawesome/fontawesome-svg-core';
 
 export interface ButtonProps {
     text: string;
@@ -13,7 +13,7 @@ export interface ButtonProps {
     disabled?: boolean;
     href?: string;
     onClick?: (e:MouseEvent) => void;
-    icon?: IconName;
+    icon?: IconProp;
 }
 
 const Button = (props: ButtonProps) => {
@@ -30,11 +30,12 @@ const Button = (props: ButtonProps) => {
         <>
             {props.href ? (
                 <a className={buttonObj}>
+                    {props.icon && <FontAwesomeIcon icon={props.icon} />}
                     {props.text}
                 </a>
             ) : (
                 <button className={buttonObj} disabled={props.disabled}>
-                    {props.icon && <FontAwesomeIcon icon={['fas', props.icon]} />}
+                    {props.icon && <FontAwesomeIcon icon={props.icon} />}
                     {props.text} 
                 </button>
             )}


### PR DESCRIPTION
Fixed the functionality so the user can choose solid, regular, or brand icons by passing an array into the Button prop

Example
`<div style={{margin: '0 5px'}}><Button text="Second Button" icon={['far', 'envelope']} /></div>`